### PR TITLE
[FEAT] 댓글 좋아요 기능 추가

### DIFF
--- a/src/main/java/pawparazzi/back/comment/controller/CommentController.java
+++ b/src/main/java/pawparazzi/back/comment/controller/CommentController.java
@@ -4,13 +4,15 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import pawparazzi.back.comment.dto.CommentRequestDto;
-import pawparazzi.back.comment.dto.CommentResponseDto;
-import pawparazzi.back.comment.dto.CommentResponseWrapperDto;
+import pawparazzi.back.comment.dto.request.CommentRequestDto;
+import pawparazzi.back.comment.dto.response.CommentLikeResponseDto;
+import pawparazzi.back.comment.dto.response.CommentLikesResponseDto;
+import pawparazzi.back.comment.dto.response.CommentResponseDto;
+import pawparazzi.back.comment.dto.response.CommentListResponseDto;
+import pawparazzi.back.comment.service.CommentLikeService;
 import pawparazzi.back.comment.service.CommentService;
 import pawparazzi.back.security.util.JwtUtil;
 
-import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -19,6 +21,7 @@ import java.util.Map;
 public class CommentController {
 
     private final CommentService commentService;
+    private final CommentLikeService commentLikeService;
     private final JwtUtil jwtUtil;
 
     /**
@@ -68,7 +71,29 @@ public class CommentController {
      * 특정 게시글의 댓글 목록 조회
      */
     @GetMapping("/{boardId}")
-    public ResponseEntity<CommentResponseWrapperDto> getComments(@PathVariable Long boardId) {
+    public ResponseEntity<CommentListResponseDto> getComments(@PathVariable Long boardId) {
         return ResponseEntity.ok(commentService.getCommentsByBoard(boardId));
+    }
+
+    /**
+     * 댓글 좋아요 등록/삭제 (토글)
+     */
+    @PostMapping("/{commentId}/like")
+    public ResponseEntity<CommentLikeResponseDto> toggleCommentLike(
+            @PathVariable Long commentId,
+            @RequestHeader("Authorization") String token) {
+
+        Long memberId = jwtUtil.extractMemberId(token.replace("Bearer ", ""));
+        CommentLikeResponseDto response = commentLikeService.toggleCommentLike(commentId, memberId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 특정 댓글에 좋아요를 누른 회원 목록 조회
+     */
+    @GetMapping("/{commentId}/likes")
+    public ResponseEntity<CommentLikesResponseDto> getLikedMembersByComment(@PathVariable Long commentId) {
+        return ResponseEntity.ok(commentLikeService.getLikedMembersByComment(commentId));
     }
 }

--- a/src/main/java/pawparazzi/back/comment/dto/request/CommentRequestDto.java
+++ b/src/main/java/pawparazzi/back/comment/dto/request/CommentRequestDto.java
@@ -1,4 +1,4 @@
-package pawparazzi.back.comment.dto;
+package pawparazzi.back.comment.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -10,8 +10,4 @@ public class CommentRequestDto {
 
     @NotBlank(message = "댓글 내용은 필수 입력값입니다.")
     private String content;
-
-    public CommentRequestDto(String content) {
-        this.content = content;
-    }
 }

--- a/src/main/java/pawparazzi/back/comment/dto/response/CommentLikeResponseDto.java
+++ b/src/main/java/pawparazzi/back/comment/dto/response/CommentLikeResponseDto.java
@@ -1,0 +1,15 @@
+package pawparazzi.back.comment.dto.response;
+
+import lombok.Getter;
+
+
+@Getter
+public class CommentLikeResponseDto {
+    private final boolean liked;
+    private final int commentsLikeCount;
+
+    public CommentLikeResponseDto(boolean liked, int commentsLikeCount) {
+        this.liked = liked;
+        this.commentsLikeCount = commentsLikeCount;
+    }
+}

--- a/src/main/java/pawparazzi/back/comment/dto/response/CommentLikesResponseDto.java
+++ b/src/main/java/pawparazzi/back/comment/dto/response/CommentLikesResponseDto.java
@@ -1,0 +1,21 @@
+package pawparazzi.back.comment.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CommentLikesResponseDto {
+    private Long commentId;
+    private int likeCount;
+    private List<LikedMemberDto> likedMembers;
+
+    @Getter
+    @AllArgsConstructor
+    public static class LikedMemberDto {
+        private Long memberId;
+        private String nickname;
+        private String profileImageUrl;
+    }
+}

--- a/src/main/java/pawparazzi/back/comment/dto/response/CommentListResponseDto.java
+++ b/src/main/java/pawparazzi/back/comment/dto/response/CommentListResponseDto.java
@@ -1,12 +1,13 @@
-package pawparazzi.back.comment.dto;
+package pawparazzi.back.comment.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
 import java.util.List;
 
 @Getter
 @AllArgsConstructor
-public class CommentResponseWrapperDto {
+public class CommentListResponseDto {
     private Long boardId;
     private int commentCount;
     private List<CommentResponseDto> comments;

--- a/src/main/java/pawparazzi/back/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/pawparazzi/back/comment/dto/response/CommentResponseDto.java
@@ -1,4 +1,4 @@
-package pawparazzi.back.comment.dto;
+package pawparazzi.back.comment.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,6 +13,7 @@ public class CommentResponseDto {
     private Long commentId;
     private MemberDto commentMember;
     private String content;
+    private int likeCount;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 

--- a/src/main/java/pawparazzi/back/comment/entity/Comment.java
+++ b/src/main/java/pawparazzi/back/comment/entity/Comment.java
@@ -29,6 +29,9 @@ public class Comment {
     @Column(nullable = false, length = 500)
     private String content;
 
+    @Column(nullable = false)
+    private int likeCount = 0;
+
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -44,4 +47,15 @@ public class Comment {
         this.content = content;
         this.updatedAt = LocalDateTime.now().withNano(0);;
     }
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
 }

--- a/src/main/java/pawparazzi/back/comment/entity/CommentLike.java
+++ b/src/main/java/pawparazzi/back/comment/entity/CommentLike.java
@@ -1,0 +1,32 @@
+package pawparazzi.back.comment.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import pawparazzi.back.member.entity.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "comment_like", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"comment_id", "member_id"})
+})
+public class CommentLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    public CommentLike(Comment comment, Member member) {
+        this.comment = comment;
+        this.member = member;
+    }
+}

--- a/src/main/java/pawparazzi/back/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/pawparazzi/back/comment/repository/CommentLikeRepository.java
@@ -1,0 +1,15 @@
+package pawparazzi.back.comment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import pawparazzi.back.comment.entity.Comment;
+import pawparazzi.back.comment.entity.CommentLike;
+import pawparazzi.back.member.entity.Member;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    Optional<CommentLike> findByCommentAndMember(Comment comment, Member member);
+    void deleteByCommentId(Long commentId);
+    List<CommentLike> findByComment(Comment comment);
+}

--- a/src/main/java/pawparazzi/back/comment/service/CommentLikeService.java
+++ b/src/main/java/pawparazzi/back/comment/service/CommentLikeService.java
@@ -1,0 +1,83 @@
+package pawparazzi.back.comment.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pawparazzi.back.comment.dto.response.CommentLikeResponseDto;
+import pawparazzi.back.comment.dto.response.CommentLikesResponseDto;
+import pawparazzi.back.comment.entity.Comment;
+import pawparazzi.back.comment.entity.CommentLike;
+import pawparazzi.back.comment.repository.CommentLikeRepository;
+import pawparazzi.back.comment.repository.CommentRepository;
+import pawparazzi.back.member.entity.Member;
+import pawparazzi.back.member.repository.MemberRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CommentLikeService {
+
+    private final CommentLikeRepository commentLikeRepository;
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 댓글 좋아요 등록/삭제 (토글)
+     */
+    @Transactional
+    public CommentLikeResponseDto toggleCommentLike(Long commentId, Long memberId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다."));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+        CommentLike existingLike = commentLikeRepository.findByCommentAndMember(comment, member).orElse(null);
+
+        boolean liked;
+        if (existingLike != null) {
+            commentLikeRepository.delete(existingLike);
+            comment.decreaseLikeCount();
+            liked = false;
+        } else {
+            commentLikeRepository.save(new CommentLike(comment, member));
+            comment.increaseLikeCount();
+            liked = true;
+        }
+
+        return new CommentLikeResponseDto(liked, comment.getLikeCount());
+    }
+
+
+    /**
+     * 특정 댓글에 좋아요를 누른 회원 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public CommentLikesResponseDto getLikedMembersByComment(Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다."));
+
+        List<CommentLike> commentLikes = commentLikeRepository.findByComment(comment);
+
+        List<CommentLikesResponseDto.LikedMemberDto> likedMembers = commentLikes.stream()
+                .map(like -> new CommentLikesResponseDto.LikedMemberDto(
+                        like.getMember().getId(),
+                        like.getMember().getNickName(),
+                        like.getMember().getProfileImageUrl()
+                ))
+                .collect(Collectors.toList());
+
+        return new CommentLikesResponseDto(commentId, likedMembers.size(), likedMembers);
+    }
+
+    /**
+     * 댓글에 달린 좋아요 삭제 (댓글 삭제 시 호출)
+     */
+    @Transactional
+    public void deleteCommentLikes(Long commentId) {
+        commentLikeRepository.deleteByCommentId(commentId);
+    }
+}

--- a/src/main/java/pawparazzi/back/exception/ApiErrorResponse.java
+++ b/src/main/java/pawparazzi/back/exception/ApiErrorResponse.java
@@ -1,11 +1,24 @@
 package pawparazzi.back.exception;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.Map;
+
 @Getter
-@AllArgsConstructor
 public class ApiErrorResponse {
     private final int status;
     private final String message;
+    private final Map<String, String> errors;
+
+    public ApiErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+        this.errors = null; // 기본적으로 오류 필드는 없는 상태
+    }
+
+    public ApiErrorResponse(int status, String message, Map<String, String> errors) {
+        this.status = status;
+        this.message = message;
+        this.errors = errors;
+    }
 }

--- a/src/main/java/pawparazzi/back/exception/GlobalExceptionHandler.java
+++ b/src/main/java/pawparazzi/back/exception/GlobalExceptionHandler.java
@@ -4,14 +4,37 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    /**
+     * 유효성 검사 실패 예외 처리 (@Valid)
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
+        log.warn("Validation Error: {}", ex.getMessage());
+
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage())
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ApiErrorResponse(HttpStatus.BAD_REQUEST.value(), "입력 값이 올바르지 않습니다.", errors));
+    }
+
+    /**
+     * 잘못된 요청 처리
+     */
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
         log.warn("IllegalArgumentException: {}", ex.getMessage());
@@ -20,6 +43,9 @@ public class GlobalExceptionHandler {
                 .body(new ApiErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage()));
     }
 
+    /**
+     * 로그인 실패 예외 처리
+     */
     @ExceptionHandler(BadCredentialsException.class)
     public ResponseEntity<ApiErrorResponse> handleBadCredentialsException(BadCredentialsException ex) {
         log.warn("BadCredentialsException: {}", ex.getMessage());
@@ -28,6 +54,9 @@ public class GlobalExceptionHandler {
                 .body(new ApiErrorResponse(HttpStatus.UNAUTHORIZED.value(), "로그인 정보가 올바르지 않습니다."));
     }
 
+    /**
+     * 엔티티 조회 실패 예외 처리
+     */
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<ApiErrorResponse> handleEntityNotFoundException(EntityNotFoundException ex) {
         log.warn("EntityNotFoundException: {}", ex.getMessage());
@@ -36,6 +65,9 @@ public class GlobalExceptionHandler {
                 .body(new ApiErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage()));
     }
 
+    /**
+     * 예상하지 못한 예외 처리
+     */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiErrorResponse> handleGeneralException(Exception ex) {
         log.error("Unhandled Exception: ", ex);


### PR DESCRIPTION
[FEAT] 댓글 좋아요 기능 추가, 에러 코드 수정

### ⛓️‍💥 Issue Number
- #44 

  <br/>
### 🔎 Summary

- 댓글 좋아요 / 취소 (토글) 이미 댓글에 좋아요를 누른상태라면 재호출 시 좋아요가 취소
- 댓글 좋아요 누른 사용자의 닉네임, 프로필이미지 불러오기

  <br/>
### ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, git template 수정)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제
