### PR TITLE
[FEAT] 카카오 로그인 기능

### DIFF
--- a/src/main/java/pawparazzi/back/config/RestTemplateConfig.java
+++ b/src/main/java/pawparazzi/back/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package pawparazzi.back.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/pawparazzi/back/member/controller/AuthController.java
+++ b/src/main/java/pawparazzi/back/member/controller/AuthController.java
@@ -1,0 +1,67 @@
+package pawparazzi.back.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import pawparazzi.back.member.dto.JwtResponseDto;
+import pawparazzi.back.member.dto.KakaoUserDto;
+import pawparazzi.back.member.service.KakaoAuthService;
+import pawparazzi.back.member.service.MemberService;
+import pawparazzi.back.security.util.JwtUtil;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+@Slf4j
+@CrossOrigin(origins = "*")
+public class AuthController {
+
+    private final KakaoAuthService kakaoAuthService;
+    private final MemberService memberService;
+    private final JwtUtil jwtUtil;
+
+    @Value("${KAKAO_CLIENT_ID}")
+    private String kakaoClientId;
+
+    @Value("${KAKAO_REDIRECT_URI}")
+    private String kakaoRedirectUri;
+
+    /**
+     * 클라이언트 ID 없이 카카오 로그인 URL로 자동 리디렉트
+     */
+    @GetMapping("/login/kakao")
+    public ResponseEntity<Void> redirectToKakaoLogin() {
+        String kakaoLoginUrl = "https://kauth.kakao.com/oauth/authorize"
+                + "?client_id=" + kakaoClientId
+                + "&redirect_uri=" + kakaoRedirectUri
+                + "&response_type=code";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(URI.create(kakaoLoginUrl));
+        return ResponseEntity.status(302).headers(headers).build();
+    }
+
+    /**
+     * 카카오 로그인 콜백 (인가 코드 → JWT 발급)
+     */
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<JwtResponseDto> kakaoLogin(@RequestParam String code) {
+        try {
+            String accessToken = kakaoAuthService.getAccessToken(code);
+            KakaoUserDto kakaoUser = kakaoAuthService.getUserInfo(accessToken);
+            Long memberId = memberService.handleKakaoLogin(kakaoUser);
+            String jwtToken = jwtUtil.generateIdToken(memberId);
+
+            return ResponseEntity.ok(new JwtResponseDto(jwtToken));
+
+        } catch (Exception e) {
+            log.error("카카오 로그인 처리 중 오류 발생: {}", e.getMessage());
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/src/main/java/pawparazzi/back/member/controller/MemberController.java
+++ b/src/main/java/pawparazzi/back/member/controller/MemberController.java
@@ -52,7 +52,7 @@ public class MemberController {
     }
 
     /**
-     * 사용자 정보 수정 (게시물 정보 제외)
+     * 사용자 정보 수정
      */
     @PatchMapping("/me")
     public ResponseEntity<UpdateMemberResponseDto> updateMember(

--- a/src/main/java/pawparazzi/back/member/dto/JwtResponseDto.java
+++ b/src/main/java/pawparazzi/back/member/dto/JwtResponseDto.java
@@ -1,0 +1,10 @@
+package pawparazzi.back.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class JwtResponseDto {
+    private String token;
+}

--- a/src/main/java/pawparazzi/back/member/dto/KakaoUserDto.java
+++ b/src/main/java/pawparazzi/back/member/dto/KakaoUserDto.java
@@ -1,0 +1,13 @@
+package pawparazzi.back.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class KakaoUserDto {
+    private Long id;
+    private String email;
+    private String nickname;
+    private String profileImageUrl;
+}

--- a/src/main/java/pawparazzi/back/member/service/KakaoAuthService.java
+++ b/src/main/java/pawparazzi/back/member/service/KakaoAuthService.java
@@ -1,0 +1,101 @@
+package pawparazzi.back.member.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import pawparazzi.back.member.dto.KakaoUserDto;
+
+import java.util.Collections;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoAuthService {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${KAKAO_CLIENT_ID}")
+    private String clientId;
+
+    @Value("${KAKAO_CLIENT_SECRET}")
+    private String clientSecret;
+
+    @Value("${KAKAO_REDIRECT_URI}")
+    private String redirectUri;
+
+    private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    /**
+     * 카카오 액세스 토큰 요청
+     */
+    public String getAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        String body = new StringBuilder()
+                .append("grant_type=authorization_code")
+                .append("&client_id=").append(clientId)
+                .append("&redirect_uri=").append(redirectUri)
+                .append("&code=").append(code)
+                .append("&client_secret=").append(clientSecret)
+                .toString();
+
+        HttpEntity<String> requestEntity = new HttpEntity<>(body, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(TOKEN_URL, HttpMethod.POST, requestEntity, String.class);
+
+            if (response.getStatusCode() != HttpStatus.OK) {
+                log.error("카카오 액세스 토큰 요청 실패: HTTP 상태 코드 {}", response.getStatusCode());
+                throw new IllegalStateException("카카오 액세스 토큰 요청 실패");
+            }
+
+            JsonNode responseJson = objectMapper.readTree(response.getBody());
+            return responseJson.get("access_token").asText();
+
+        } catch (Exception e) {
+            log.error("카카오 액세스 토큰 요청 중 오류 발생: {}", e.getMessage());
+            throw new IllegalStateException("카카오 액세스 토큰 요청 실패");
+        }
+    }
+
+    /**
+     * 카카오 사용자 정보 요청
+     */
+    public KakaoUserDto getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(USER_INFO_URL, HttpMethod.GET, entity, String.class);
+
+            if (response.getStatusCode() != HttpStatus.OK) {
+                log.error("카카오 사용자 정보 요청 실패: HTTP 상태 코드 {}", response.getStatusCode());
+                throw new IllegalStateException("카카오 사용자 정보 요청 실패");
+            }
+
+            JsonNode userJson = objectMapper.readTree(response.getBody());
+
+            return new KakaoUserDto(
+                    userJson.get("id").asLong(),
+                    userJson.get("kakao_account").get("email").asText(),
+                    userJson.get("kakao_account").get("profile").get("nickname").asText(),
+                    userJson.get("kakao_account").get("profile").get("profile_image_url").asText()
+            );
+
+        } catch (Exception e) {
+            log.error("카카오 사용자 정보 요청 중 오류 발생: {}", e.getMessage());
+            throw new IllegalStateException("카카오 사용자 정보 요청 실패");
+        }
+    }
+}

--- a/src/main/java/pawparazzi/back/member/service/MemberService.java
+++ b/src/main/java/pawparazzi/back/member/service/MemberService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import pawparazzi.back.board.entity.Board;
 import pawparazzi.back.board.repository.BoardMongoRepository;
 import pawparazzi.back.board.repository.BoardRepository;
+import pawparazzi.back.member.dto.KakaoUserDto;
 import pawparazzi.back.member.dto.request.LoginRequestDto;
 import pawparazzi.back.member.dto.request.SignUpRequestDto;
 import pawparazzi.back.member.dto.request.UpdateMemberRequestDto;
@@ -19,6 +20,7 @@ import pawparazzi.back.security.util.JwtUtil;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 
 @Service
@@ -126,5 +128,29 @@ public class MemberService {
         boardRepository.deleteByAuthor(member);
 
         memberRepository.delete(member);
+    }
+
+    /**
+     * 카카오 로그인 회원 처리
+     */
+    @Transactional
+    public Long handleKakaoLogin(KakaoUserDto kakaoUser) {
+        Optional<Member> existingMember = memberRepository.findByEmail(kakaoUser.getEmail());
+
+        if (existingMember.isPresent()) {
+            return existingMember.get().getId();
+        } else {
+            String randomPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+
+            Member newMember = new Member(
+                    kakaoUser.getEmail(),
+                    randomPassword,
+                    kakaoUser.getNickname(),
+                    kakaoUser.getProfileImageUrl(),
+                    kakaoUser.getNickname()
+            );
+            memberRepository.save(newMember);
+            return newMember.getId();
+        }
     }
 }


### PR DESCRIPTION
[FEAT] 카카오 로그인 기능

### ⛓️‍💥 Issue Number
- #59 

  <br/>
### 🔎 Summary

-프론트엔드 → GET /auth/login/kakao 요청
-백엔드가 카카오 로그인 페이지로 리디렉트
-사용자가 카카오 로그인 완료 후 인가 코드 반환
-백엔드가 인가 코드로 액세스 토큰 요청
- 카카오 사용자 정보 요청 후 회원 가입 / 로그인 처리
- JWT 발급 후 프론트엔드로 반환

  <br/>
### ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, git template 수정)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제
