### PR TITLE
[FEAT] 전체 회원 목록 조회 기능

### DIFF
--- a/src/main/java/pawparazzi/back/member/controller/MemberController.java
+++ b/src/main/java/pawparazzi/back/member/controller/MemberController.java
@@ -7,11 +7,13 @@ import org.springframework.web.bind.annotation.*;
 import pawparazzi.back.member.dto.request.LoginRequestDto;
 import pawparazzi.back.member.dto.request.SignUpRequestDto;
 import pawparazzi.back.member.dto.request.UpdateMemberRequestDto;
+import pawparazzi.back.member.dto.response.MemberResponseDto;
 import pawparazzi.back.member.dto.response.UpdateMemberResponseDto;
 import pawparazzi.back.member.entity.Member;
 import pawparazzi.back.member.service.MemberService;
 import pawparazzi.back.security.util.JwtUtil;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -74,5 +76,15 @@ public class MemberController {
         Long memberId = jwtUtil.extractMemberId(token);
         memberService.deleteMember(memberId);
         return ResponseEntity.ok("회원 탈퇴 완료");
+    }
+
+
+    /**
+     * 전체 회원 목록 조회 API
+     */
+    @GetMapping
+    public ResponseEntity<List<MemberResponseDto>> getAllMembers() {
+        List<MemberResponseDto> members = memberService.getAllMembers();
+        return ResponseEntity.ok(members);
     }
 }

--- a/src/main/java/pawparazzi/back/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/pawparazzi/back/member/dto/response/MemberResponseDto.java
@@ -1,0 +1,13 @@
+package pawparazzi.back.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberResponseDto {
+    private Long id;
+    private String name;
+    private String nickName;
+    private String profileImage;
+}

--- a/src/main/java/pawparazzi/back/member/service/MemberService.java
+++ b/src/main/java/pawparazzi/back/member/service/MemberService.java
@@ -13,6 +13,7 @@ import pawparazzi.back.member.dto.KakaoUserDto;
 import pawparazzi.back.member.dto.request.LoginRequestDto;
 import pawparazzi.back.member.dto.request.SignUpRequestDto;
 import pawparazzi.back.member.dto.request.UpdateMemberRequestDto;
+import pawparazzi.back.member.dto.response.MemberResponseDto;
 import pawparazzi.back.member.dto.response.UpdateMemberResponseDto;
 import pawparazzi.back.member.entity.Member;
 import pawparazzi.back.member.repository.MemberRepository;
@@ -21,6 +22,7 @@ import pawparazzi.back.security.util.JwtUtil;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 
 @Service
@@ -127,6 +129,21 @@ public class MemberService {
         }
 
         memberRepository.delete(member);
+    }
+
+    /**
+     * 전체 회원 목록 조회
+     */
+    @Transactional
+    public List<MemberResponseDto> getAllMembers() {
+        return memberRepository.findAll().stream()
+                .map(member -> new MemberResponseDto(
+                        member.getId(),
+                        member.getName(),
+                        member.getNickName(),
+                        member.getProfileImageUrl()
+                ))
+                .collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
[FEAT] 전체 회원 목록 조회 기능

### ⛓️‍💥 Issue Number
- #66 

  <br/>
### 🔎 Summary

- member 패키지에 GET /api/v1/auth 구현
- 모든 회원의 id, 닉네임, 이름 , 프로필이미지 값 반환

  <br/>
### ✅ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경, git template 수정)
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정/삭제
